### PR TITLE
Patch 1

### DIFF
--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM arm32v7/alpine
+FROM arm32v7/alpine:3.12
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm-Dockerfile
+++ b/docker/arm-Dockerfile
@@ -1,4 +1,4 @@
-FROM multiarch/alpine:armhf-latest-stable
+FROM arm32v7/alpine
 
 #install python
 RUN apk update && apk add \

--- a/docker/arm64-Dockerfile
+++ b/docker/arm64-Dockerfile
@@ -1,4 +1,4 @@
-FROM multiarch/alpine:aarch64-latest-stable
+FROM arm64v8/alpine:3.12
 
 #install python
 RUN apk update && apk add \


### PR DESCRIPTION
Limit to v3.12 in Alpine because 3.13+ can't work with Raspbian due to time64 requirements. https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.13.0#time64_requirements